### PR TITLE
Remove commitentry suffix from entries

### DIFF
--- a/files.go
+++ b/files.go
@@ -77,6 +77,11 @@ func processFile(filePath, name string, minAge time.Duration, now time.Time) (*F
 		if len(lines) > 0 {
 			lastLine := strings.TrimSpace(lines[len(lines)-1])
 			commit = lastLine == "commitentry"
+			if commit {
+				// Remove the "commitentry" line from content
+				lines = lines[:len(lines)-1]
+				content = strings.Join(lines, "\n")
+			}
 		}
 	}
 


### PR DESCRIPTION
When a file ends with "commitentry", the marker is now stripped from the content before creating Day One entries or Things tasks. The marker is still used internally to determine if a file should be committed, but it won't appear in the final output sent to integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where trailing "commitentry" markers were not being removed from file content during processing. Files now have these markers automatically cleaned up when detected as the last non-empty line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->